### PR TITLE
TCP通信でチャットルームへの参加・作成リクエスト送信とレスポンス受信 #3

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -3,6 +3,7 @@ import threading
 import time
 import struct
 import json
+from constants.operation import Operation
 
 class Client:
     NAME_SIZE = 255
@@ -48,13 +49,13 @@ class Client:
             break
 
     def tcp_connect_server(self):
-        # try:
+        try:
             self.tcp_client_sock.connect((self.server_address, self.tcp_server_port))
             custom_tcp_request = self.create_tcp_request()
             self.tcp_client_sock.sendall(custom_tcp_request)
             self.receive_tcp_response()
-        # except Exception as e:
-        #     print(f"An error occurred while connecting to the server: {e}")
+        except Exception as e:
+            print(f"An error occurred while connecting to the server: {e}")
 
     def create_tcp_request(self):
 
@@ -65,7 +66,7 @@ class Client:
             try:
                 print("Please enter 1 or 2 : ")
                 self.operation_code = int(input())
-                if int(self.operation_code) in [Client.CREATE_ROOM, Client.JOIN_ROOM]:
+                if int(self.operation_code) in [Operation.CREATE_ROOM.value, Operation.JOIN_ROOM.value]:
                     break
             except Exception:
                 continue
@@ -133,12 +134,14 @@ class Client:
             print("-------- レスポンス   -----------")
             
             if response_state == 2:
+                self.token = operation_payload['token']
+                print(operation_payload['message'])
+            else:
                 # operation_payload_bytesが空でないことを確認
                 if not operation_payload:
                     print("No payload received, or the connection was closed.")
-                    break
-                self.token = operation_payload['token']
-                print('ルームの作成が完了しました')
+                print(operation_payload['message'])    
+                break
             self.tcp_client_sock.close()
             break
     

--- a/client/client.py
+++ b/client/client.py
@@ -140,8 +140,8 @@ class Client:
                 # operation_payload_bytesが空でないことを確認
                 if not operation_payload:
                     print("No payload received, or the connection was closed.")
+                    break
                 print(operation_payload['message'])    
-                break
             self.tcp_client_sock.close()
             break
     

--- a/client/client.py
+++ b/client/client.py
@@ -1,26 +1,43 @@
 import socket
 import threading
 import time
+import struct
+import json
 
 class Client:
     NAME_SIZE = 255
+    ROOM_NAME_SIZE = 255
+    HEADER_SIZE = 32
     BUFFER_SIZE = 4096
+    CREATE_ROOM = 1
+    JOIN_ROOM = 2
 
-    def __init__(self, server_address='0.0.0.0', server_port=9001):
-        self.client_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.server_address = server_address
-        self.server_port = server_port
+    def __init__(self, server_address='0.0.0.0'):
+        self.udp_client_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.tcp_client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_address  = server_address
+        self.tcp_server_port = 9000
+        self.udp_server_port = 9001
         self.user_name = ''
         self.name_size = 0
+        self.room_name = ''
+        self.operation_code = 0
+        self.state = 0
+        self.password = ''
+        self.token = ''
+        
 
     def start(self):
-        self.create_user()
-        thread_send = threading.Thread(target=self.send_message, daemon=True)
-        thread_send.start()
-        thread_recieve_message = threading.Thread(target=self.receive_message, daemon=True)
-        thread_recieve_message.start()
+        self.input_username()
+        self.tcp_connect_server()
+        # thread_send = threading.Thread(target=self.send_message, daemon=True)
+        # TODO:UDP通信のissueで使うためコメントアウト
+        # thread_send = threading.Thread(target=self.udp_send_message, daemon=True)
+        # thread_send.start()
+        # thread_recieve_message = threading.Thread(target=self.receive_message, daemon=True)
+        # thread_recieve_message.start()  
 
-    def create_user(self):
+    def input_username(self):
         while True:
             user_name = input('Enter your name: ')
             if (len(user_name.encode()) > Client.NAME_SIZE):
@@ -30,6 +47,101 @@ class Client:
             self.user_name = user_name
             break
 
+    def tcp_connect_server(self):
+        # try:
+            self.tcp_client_sock.connect((self.server_address, self.tcp_server_port))
+            custom_tcp_request = self.create_tcp_request()
+            self.tcp_client_sock.sendall(custom_tcp_request)
+            self.receive_tcp_response()
+        # except Exception as e:
+        #     print(f"An error occurred while connecting to the server: {e}")
+
+    def create_tcp_request(self):
+
+        # ルーム作成 or 参加の指定
+        while True:
+            print("1. Create a new room\n"
+                "2. Join room\n")
+            try:
+                print("Please enter 1 or 2 : ")
+                self.operation_code = int(input())
+                if int(self.operation_code) in [Client.CREATE_ROOM, Client.JOIN_ROOM]:
+                    break
+            except Exception:
+                continue
+        
+        # ルーム名の記入
+        while True:
+            self.room_name = input('Enter room name: ')
+            # ルーム名のサイズ確認
+            if len(self.room_name) > Client.ROOM_NAME_SIZE:
+                print(f"Your name must equal to less than {Client.ROOM_NAME_SIZE} bytes")
+                continue
+            # stage3で使うため一旦、コメントアウト
+            # self.password = input('Enter PassWord: ')
+            break
+                
+        # 必要に応じてパスワードなどを追加する
+        operation_payload = {"user_name":self.user_name}
+        
+        
+        return self.create_tcp_protocol(operation_payload)
+    
+    def create_tcp_protocol(self, operation_payload: dict):
+
+        # ペイロードをJSON文字列に変換し、バイト列にエンコード
+        operation_payload_bytes = json.dumps(operation_payload).encode('utf-8')
+        operation_payload_size_bytes = len(operation_payload_bytes).to_bytes(29, 'big')
+        
+        """
+        送信プロトコル確認用：後で削除
+        """
+        print("-------- リクエスト   -----------")
+        print("Room Name:", self.room_name)
+        print("User Name:", self.user_name)
+        print("Operation:", self.operation_code)
+        print("State:", self.state)
+        print("Payload:", operation_payload)
+        print("-------- リクエスト ---------")
+        
+        header = struct.pack('!B B B 29s', len(self.room_name), self.operation_code, self.state, operation_payload_size_bytes)
+        body = self.room_name.encode('utf-8') + operation_payload_bytes
+        return header + body
+    
+    def receive_tcp_response(self):
+
+        while True:
+            header_bytes = self.tcp_client_sock.recv(Client.HEADER_SIZE)
+            room_name_size = header_bytes[0]
+            operation_code = header_bytes[1]
+            response_state = header_bytes[2]
+            operation_payload_size = int.from_bytes(header_bytes[3:], 'big')
+            
+            body_bytes = self.tcp_client_sock.recv(room_name_size + operation_payload_size)
+            self.room_name = body_bytes[:room_name_size].decode('utf-8')
+            operation_payload = json.loads(body_bytes[room_name_size:].decode('utf-8'))
+
+            """
+            受信プロトコル確認用：後で削除
+            """
+            print("-------- レスポンス   -----------")
+            print(f'room_name_size: {room_name_size}')
+            print(f'operation_code: {operation_code}')
+            print(f'State: {response_state}')
+            print(f'room_name: {self.room_name}') 
+            print(f'Payload: {operation_payload}') 
+            print("-------- レスポンス   -----------")
+            
+            if response_state == 2:
+                # operation_payload_bytesが空でないことを確認
+                if not operation_payload:
+                    print("No payload received, or the connection was closed.")
+                    break
+                self.token = operation_payload['token']
+                print('ルームの作成が完了しました')
+            self.tcp_client_sock.close()
+            break
+    
     def send_message(self):
         try:
             print('Enter your message')


### PR DESCRIPTION
## チケット
#3 

## 目的
・クライアントからのルーム作成or参加リクエストの送信
・サーバーからのレスポンスの受信

## 概要
### 入力は名前とルーム作成or参加を選択しルーム名を入力

![image](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/f21ab20f-89c6-42ef-86dd-b63986ac8a1c)

### クライアントからのリクエスト例は以下の通り。
Payloadはjson形式で送信。

![image](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/3610a21b-5bfa-4e5f-8a71-341ddb31355c)

### サーバーからのレスポンス例は以下の通り。
Payloadはjson形式で受信。

![image](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/09d2e4ab-0264-448b-96c5-20909fedc01b)

## レビューしてほしいところ
・要件の通りの実装になっているか
・処理の流れがわかりやすく、変数名や関数名が適切か