### PR TITLE
Feature/#10 add auth password

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -123,6 +123,8 @@ class Client:
                     print("No payload received, or the connection was closed.")
                     break
                 print(operation_payload['message'])
+                self.shutdown()
+
             self.tcp_client_sock.close()
             break
 
@@ -167,6 +169,10 @@ class Client:
                 message = data[2 + user_name_size:]
                 if user_name.decode('utf-8') != self.user_name:
                     print(f"{user_name.decode('utf-8')}：{message.decode('utf-8')}")
+
+        except OSError:
+            pass
+
         finally:
             print('socket closing')
             self.udp_client_sock.close()
@@ -189,12 +195,18 @@ class Client:
             print(f"Your name must be less than {Client.ROOM_NAME_SIZE} bytes")
 
     def prompt_for_password(self):
-        return input('Enter Password: ')
+        while True:
+            password = input('Enter Password: ')
+            if len(password) < 6:
+                print("Password must be at least 6 characters long.")
+            else:
+                return password
 
     def shutdown(self):
         print("Client is shutting down.")
         self.udp_client_sock.close()
         self.tcp_client_sock.close()
+        exit()
 
 
 if __name__ == "__main__":

--- a/client/client.py
+++ b/client/client.py
@@ -56,35 +56,15 @@ class Client:
             print(f"An error occurred while connecting to the server: {e}")
 
     def create_tcp_request(self):
+        self.operation_code = self.prompt_for_operation_code()
+        self.room_name = self.prompt_for_room_name()
+        self.password = self.prompt_for_password()
 
-        # ルーム作成 or 参加の指定
-        while True:
-            print("1. Create a new room\n"
-                "2. Join room")
-            try:
-                print("Please enter 1 or 2 : ")
-                self.operation_code = int(input())
-                if int(self.operation_code) in [Operation.CREATE_ROOM.value, Operation.JOIN_ROOM.value]:
-                    break
-            except Exception:
-                continue
-
-        # ルーム名の記入
-        while True:
-            self.room_name = input('Enter room name: ')
-            # ルーム名のサイズ確認
-            if len(self.room_name) > Client.ROOM_NAME_SIZE:
-                print(f"Your name must equal to less than {Client.ROOM_NAME_SIZE} bytes")
-                continue
-            # stage3で使うため一旦、コメントアウト
-            # self.password = input('Enter PassWord: ')
-            break
-
-        # 必要に応じてパスワードなどを追加する
         operation_payload = {
             "user_name":self.user_name,
             "ip": self.udp_client_address[0],
-            "port": self.udp_client_address[1]
+            "port": self.udp_client_address[1],
+            "password": self.password
         }
 
         return self.create_tcp_protocol(operation_payload)
@@ -190,6 +170,26 @@ class Client:
         finally:
             print('socket closing')
             self.udp_client_sock.close()
+
+    def prompt_for_operation_code(self):
+        while True:
+            print("1. Create a new room\n2. Join room")
+            try:
+                operation_code = int(input("Please enter 1 or 2: "))
+                if operation_code in [Operation.CREATE_ROOM.value, Operation.JOIN_ROOM.value]:
+                    return operation_code
+            except ValueError:
+                print("Invalid input. Please enter 1 or 2.")
+
+    def prompt_for_room_name(self):
+        while True:
+            room_name = input('Enter room name: ')
+            if len(room_name) <= Client.ROOM_NAME_SIZE:
+                return room_name
+            print(f"Your name must be less than {Client.ROOM_NAME_SIZE} bytes")
+
+    def prompt_for_password(self):
+        return input('Enter Password: ')
 
     def shutdown(self):
         print("Client is shutting down.")

--- a/server/chat_room.py
+++ b/server/chat_room.py
@@ -2,8 +2,9 @@ import time
 from server.user import User
 
 class ChatRoom:
-    def __init__(self, room_name):
+    def __init__(self, room_name, password):
         self.room_name = room_name
+        self.password = password
         self.users = {}
 
     # user追加

--- a/server/server.py
+++ b/server/server.py
@@ -213,10 +213,14 @@ class Server:
             MemberType.HOST.value if operation == Operation.CREATE_ROOM.value else MemberType.GUEST.value
         )
 
-    def join_room(self, user, room_name):
-        if self.rooms.get(room_name) is not None:
-            self.rooms[room_name].add_user(user)
-            return {"status": 200, "message": "Joined chat room successfully."}
+    def join_room(self, user, room_name, password):
+        room = self.rooms.get(room_name)
+        if room is not None:
+            if room.password != password:
+                return {"status": 401, "message": "Incorrect password."}
+            else:
+                room.add_user(user)
+                return {"status": 200, "message": "Joined chat room successfully."}
         else:
             return {"status": 404, "message": "Chat room not found."}
 

--- a/server/server.py
+++ b/server/server.py
@@ -18,15 +18,6 @@ class Server:
     TOKEN_MAX_BITE = 80
     MAX_MESSAGE_SIZE = 4096
 
-    STATUS_MESSAGE = {
-        200: 'Successfully joined a chat room',
-        201: 'Successfully create a chat room',
-        202: 'Server accpeted your request',
-        401: 'Token or room password is invalid',
-        404: 'Requested chat room does not exist',
-        409: 'Requested room name or username already exists',
-    }
-
     def __init__(self, tcp_address = "127.0.0.1", udp_address = "127.0.0.1"):
         self.tcp_address = tcp_address
         self.udp_address = udp_address

--- a/server/server.py
+++ b/server/server.py
@@ -4,6 +4,7 @@ import time
 import struct
 import json
 import secrets
+import re
 from constants.operation import Operation
 from constants.member_type import MemberType
 from server.user import User
@@ -82,10 +83,11 @@ class Server:
 
             operation_response = {}
             if operation == Operation.CREATE_ROOM.value:
-                operation_response = self.create_room(user, room_name)
+                operation_response = self.create_room(user, room_name, payload['password'])
             elif operation == Operation.JOIN_ROOM.value:
-                operation_response = self.join_room(user, room_name)
+                operation_response = self.join_room(user, room_name, payload['password'])
 
+            print(operation_response)
             # 状態を更新
             if operation_response["status"] in [200, 201]:
                 state = 2
@@ -189,12 +191,15 @@ class Server:
 
         return False
 
-    def create_room(self, user, room_name):
+    def create_room(self, user, room_name, password):
+        validation_message = self.is_valid_password(password)
+        if validation_message:
+            return {"status": 400, "message": validation_message}
+
         if self.rooms.get(room_name) is None:
-            chat_room = ChatRoom(room_name)
+            chat_room = ChatRoom(room_name, password)
             chat_room.add_user(user)
             self.rooms[room_name] = chat_room
-
             return {"status": 200, "message": "Chat room created successfully."}
         else:
             return {"status": 400, "message": "Chat room already exists."}
@@ -249,6 +254,15 @@ class Server:
         finally:
             print('socket closig....')
             self.udp_socket.close()
+
+    def is_valid_password(self, password):
+        if len(password) < 6:
+            return "Password must be at least 6 characters long."
+        if not re.search("[0-9]", password):
+            return "Password must contain at least one digit."
+        if not re.search("[a-zA-Z]", password):
+            return "Password must contain at least one letter."
+        return None
 
     def shutdown(self):
         print("Server is shutting down.")


### PR DESCRIPTION
## チケットへのリンク
#10 

## やったこと
- パスワードでの認証
- パスワードのバリデーション設定
- エラーコード返却時にプログラム終了処理を追加
　- 現状だとエラーが返ってきてもメッセージ入力画面に移行してしまうため

## バリデーションルール
- 6文字以上
- 数字を含むこと
- アルファベットを含むこと

## 認証失敗時の動き
- パスワード認証で失敗した場合対応したエラーコードを返却
- エラーを受け取ったクライアントはプログラムを終了させる

## 動作確認
### 正常動作時
<img width="1898" alt="スクリーンショット 2023-12-13 9 40 51" src="https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/69625901/942e19d9-3c35-4afe-a2f8-6c7f4e7b8bf2">

### ルーム作成 or 参加時に認証に失敗した時

<img width="632" alt="スクリーンショット 2023-12-13 9 45 43" src="https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/69625901/3230fba7-c8aa-4213-9430-9b4136530e2e">
