### PR TITLE
パスワード、暗号通信を取り込んだGUIに修正。

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -157,7 +157,7 @@ class Client:
             print('socket closing....')
             self.udp_client_sock.close()
 
-    def udp_message_encode(self, message_byte:str):
+    def udp_message_encode(self, message_byte:bytes):
         # ヘッダー[2BYTE] + ボディ[ルーム名 + トークン + メッセージ]
         header = struct.pack('!B B', len(self.room_name), len(self.token))
 
@@ -222,6 +222,10 @@ class Client:
             password = input('Enter Password: ')
             if len(password) < 6:
                 print("Password must be at least 6 characters long.")
+            elif not any(char.isdigit() for char in password):
+                print("Password must contain at least one digit.")
+            elif not any(char.isalpha() for char in password):
+                print("Password must contain at least one letter.")
             else:
                 return password
 

--- a/server/chat_room.py
+++ b/server/chat_room.py
@@ -5,7 +5,7 @@ from cryptography.hazmat.primitives import serialization, asymmetric, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
 class ChatRoom:
-    TIME_OUT = 20
+    TIME_OUT = 60
 
     def __init__(self, room_name, password):
         self.room_name = room_name


### PR DESCRIPTION
## やったこと

- CLIでパスワードのバリデーションを追加（CLI6文字以上だけのバリデーションだとバグるのを言い忘れました）
- GUIでのチャットのやり取り
- タイムアウト時間を60秒に設定

## 確認してほしいところ
- **CLIのパスワード入力でTCP送信する前にバリデーションがかかること。**   ←これやっぱり余計な修正だったかもしれません。
- GUIでのチャットが出来ること
- クライアントが退出したら通知されること
- ホストが退出したら、ほかのクライアントのウィンドウも閉じられること


# 参考画像
## 参加画面
![スクリーンショット 2023-12-15 231153](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/24b71b9d-216f-442b-a6c6-8e2ead7606ba)
## 参加後
![スクリーンショット 2023-12-15 232422](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/b07cc0e9-acc1-455f-8569-3f72db3f00fd)
## メッセージ送信
![スクリーンショット 2023-12-15 232437](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/fb3db725-7f5b-4fd9-871c-f999ef51a845)
## ユーザー２が退出
![スクリーンショット 2023-12-15 232458](https://github.com/Recursion-GroupB-Backend/Online-Chat-Messenger/assets/84727188/a39e326a-d252-48a1-9495-772ad933a4bb)
## ホストが退出するとほかのチャットウィンドウも全て閉じられます。
